### PR TITLE
Version Bump Validation Bug Fix

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.2.2"
+version = "1.2.3"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/validate/pre_build_validation/version_bump_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/version_bump_validation.py
@@ -80,6 +80,9 @@ class VersionBumpValidation:
             "main", head_sha, integration_path
         )
 
+        if not changed_files:
+            return
+
         rn_path: pathlib.Path | None = None
         toml_path: pathlib.Path | None = None
         for p in changed_files:

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Version Bump Validation Bug Fix

---

## Description
Bug was caused that if no changed files are found, it will still raised a validation.


**How does this PR solve the problem?**
if no changed files was found we exit the validation with no error
