### PR TITLE
updated mp validate + test + build.

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.5.1"
+version = "1.5.2"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/build_project/__init__.py
+++ b/packages/mp/src/mp/build_project/__init__.py
@@ -34,6 +34,7 @@ import typer
 import mp.core.config
 import mp.core.file_utils
 from mp.core.custom_types import RepositoryType
+from mp.core.utils import ensure_valid_list
 
 from .marketplace import Marketplace
 from .post_build.duplicate_integrations import raise_errors_for_duplicate_integrations
@@ -151,6 +152,10 @@ def build(  # noqa: PLR0913
         verbose: Verbose log options
 
     """
+    repository = ensure_valid_list(repository)
+    integration = ensure_valid_list(integration)
+    group = ensure_valid_list(group)
+
     run_params: RuntimeParams = mp.core.config.RuntimeParams(quiet, verbose)
     run_params.set_in_config()
 

--- a/packages/mp/src/mp/core/utils.py
+++ b/packages/mp/src/mp/core/utils.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from mp.core.constants import WINDOWS_PLATFORM
+
+if TYPE_CHECKING:
+    from .custom_types import RepositoryType
 
 SNAKE_PATTERN_1 = re.compile(r"(.)([A-Z][a-z]+)")
 SNAKE_PATTERN_2 = re.compile(r"([a-z0-9])([A-Z])")
@@ -115,3 +118,22 @@ def is_windows() -> bool:
 
     """
     return sys.platform.startswith(WINDOWS_PLATFORM)
+
+
+def ensure_valid_list(value: list[str] | list[RepositoryType] | type) -> list:
+    """Ensure that the input is a valid list.
+
+    This function checks whether the given value is a valid list. If the value is
+    the `type` object (e.g., `<class 'list'>`), which can happen in github actions.
+    it returns an empty list Otherwise, it returns the value as-is.
+
+    Args:
+        value (list[str] | list[RepositoryType] | type): The value to validate.
+
+    Returns:
+        list: A valid list object. Returns an empty list if the input was of type `type`.
+
+    """
+    if isinstance(value, type):
+        return []
+    return value

--- a/packages/mp/src/mp/run_pre_build_tests/__init__.py
+++ b/packages/mp/src/mp/run_pre_build_tests/__init__.py
@@ -29,7 +29,7 @@ import mp.core.file_utils
 import mp.core.unix
 from mp.core.code_manipulation import TestWarning
 from mp.core.custom_types import Products, RepositoryType
-from mp.core.utils import is_windows
+from mp.core.utils import ensure_valid_list, is_windows
 
 from .display import display_test_reports
 from .process_test_output import IntegrationTestResults, TestIssue, process_pytest_json_report
@@ -141,6 +141,10 @@ def run_pre_build_tests(  # noqa: PLR0913
     """
     if raise_error_on_violations:
         warnings.filterwarnings("error")
+
+    repository = ensure_valid_list(repository)
+    integration = ensure_valid_list(integration)
+    group = ensure_valid_list(group)
 
     run_params: RuntimeParams = mp.core.config.RuntimeParams(quiet, verbose)
     run_params.set_in_config()

--- a/packages/mp/src/mp/validate/__init__.py
+++ b/packages/mp/src/mp/validate/__init__.py
@@ -26,6 +26,7 @@ import mp.core.config
 import mp.core.file_utils
 from mp.build_project.marketplace import Marketplace
 from mp.core.custom_types import RepositoryType
+from mp.core.utils import ensure_valid_list
 
 from .data_models import FullReport, ValidationResults
 from .display import display_validation_reports
@@ -150,6 +151,10 @@ def validate(  # noqa: PLR0913
             typer.Exit: If one of the validations during the run failed
 
     """
+    repository = ensure_valid_list(repository)
+    integration = ensure_valid_list(integration)
+    group = ensure_valid_list(group)
+
     run_params: RuntimeParams = mp.core.config.RuntimeParams(quiet, verbose)
     run_params.set_in_config()
 

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Fix: Normalize repository integration and group arguments to prevent type errors in GitHub Actions

## Description

An unexpected error occurs when running the mp commands: validate, test, and build in GitHub Actions.
The Python interpreter resolves missing CLI flags (e.g., --integration or --group) as the type object (<class 'list'>) rather than as an empty list ([]), which leads to runtime errors such as:
``` │Invalid value: Only one of --repository, --groups, or --integration shall be used.      ```
or
```python
TypeError: 'type' object is not iterable
```

**How does this PR solve the problem?**
Introduces a utility function ensure_valid_list() that checks if an input value is incorrectly set as the type object (list, str, etc.).
If such a case is detected, the function returns an empty list instead of allowing the program to crash.


